### PR TITLE
fix: initialize UnsafeTrie root ValueLocation to -1

### DIFF
--- a/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
+++ b/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
@@ -52,7 +52,7 @@ namespace TrieHard.Collections
             var nodeSize = UnsafeTrieNode.Size;
             EnsureNodeSpace();
             rootPointer = (UnsafeTrieNode*)buffer.CurrentAddress;
-            *rootPointer = new UnsafeTrieNode();
+            *rootPointer = new UnsafeTrieNode { ValueLocation = -1 };
             RecordNode();
         }
 

--- a/test/TrieHard.Tests/PrefixLookupTests.cs
+++ b/test/TrieHard.Tests/PrefixLookupTests.cs
@@ -254,6 +254,20 @@ public abstract class PrefixLookupTests<T> where T : IPrefixLookup<TestRecord?>
         }
         Assert.That(lookup.Count, Is.EqualTo(valuesToAdd));
     }
+
+    [Test]
+    public void Enumerate_DoesNotYieldPhantomRootEntry()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+        T lookup = (T)T.Create(testKvpEnumerable!);
+
+        var keys = new List<string>();
+        foreach (var kv in (IEnumerable<KeyValue<TestRecord?>>)lookup)
+            keys.Add(kv.Key);
+
+        Assert.That(keys, Has.Count.EqualTo(lookup.Count));
+        Assert.That(keys, Has.None.EqualTo(""));
+    }
 }
 
 


### PR DESCRIPTION
UnsafeTrieNode uses -1 as a sentinel in ValueLocation, so a default-constructed root (which will have ValueLocation=0) falsely claims to own values[0].

This causes GetEnumerator() to yield a phantom entry with key='' and value=values[0] since it starts directly at the root pointer (unlike Get/Search/SearchValues which go through FindNodeAddress and never return the root).

Added a regression test that verifies enumeration count matches trie.Count and no empty-key entry appears.