### PR TITLE
ft: longestprefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ not store whole keys and can only be used to check for the existence of complete
 
 # Typical Alternatives to Tries
 
-The most common alternative for implementing a prefix lookup is a naïve enumeration over a list.
+The most common alternative for implementing a prefix lookup is a naï¿½ve enumeration over a list.
 Typically this could be done with a LINQ Where query passing in a lambda to check if each key element StartsWith
 a given search text. This can perform well for smaller collections, but quickly becomes a hindrance with
 millions of items.
@@ -84,8 +84,10 @@ additional latency and networking concerns.
 In TrieHard.Abstractions is an interface IPrefixLookup. All implementations
 in this project implement that interface. An IPrefixLookup has an indexer and
 can be enumerated for key value pairs like a Dictionary, but also exposes
-Search and SearchValues methods which take a key prefix and return enumerables
-of KeyValuePairs or the generic value results respectively.
+Search, SearchValues, and LongestPrefix methods. Search and SearchValues take a
+key prefix and return enumerables of KeyValuePairs or the generic value results
+respectively, while LongestPrefix returns the value associated with the longest
+stored key that prefixes the supplied key.
 
 ### [PrefixLookup](https://github.com/keithwill/TrieHard/tree/main/src/TrieHard.PrefixLookup)
 

--- a/src/TrieHard.Alternatives/List/ListPrefixLookup.cs
+++ b/src/TrieHard.Alternatives/List/ListPrefixLookup.cs
@@ -70,6 +70,30 @@ namespace TrieHard.Alternatives.List
             return values.Where(x => x.Key.StartsWith(keyPrefix)).Select(x => x.Value);
         }
 
+        public T? LongestPrefix(string key)
+        {
+            int longestKeyLength = -1;
+            T? longestValue = default;
+
+            foreach (var kvp in values)
+            {
+                if (!key.StartsWith(kvp.Key))
+                {
+                    continue;
+                }
+
+                if (kvp.Key.Length <= longestKeyLength)
+                {
+                    continue;
+                }
+
+                longestKeyLength = kvp.Key.Length;
+                longestValue = kvp.Value;
+            }
+
+            return longestKeyLength >= 0 ? longestValue : default;
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();

--- a/src/TrieHard.Alternatives/SQLite/SQLiteLookup.cs
+++ b/src/TrieHard.Alternatives/SQLite/SQLiteLookup.cs
@@ -28,6 +28,9 @@ namespace TrieHard.Alternatives.SQLite
         private SqliteCommand? getCommand;
         private SqliteParameter? getKeyParameter;
 
+        private SqliteCommand? longestPrefixCommand;
+        private SqliteParameter? longestPrefixKeyParameter;
+
         public SQLiteLookup() 
         {
             connectionString = $"Data Source=:memory:";
@@ -69,6 +72,9 @@ namespace TrieHard.Alternatives.SQLite
 
             lookup.getCommand = new SqliteCommand("SELECT ValueIndex FROM lookup WHERE Key = @Key", lookup.connection);
             lookup.getKeyParameter = lookup.getCommand.Parameters.Add("@Key", SqliteType.Text);
+
+            lookup.longestPrefixCommand = new SqliteCommand("SELECT ValueIndex FROM lookup WHERE substr(@Key, 1, length(Key)) = Key ORDER BY length(Key) DESC LIMIT 1", lookup.connection);
+            lookup.longestPrefixKeyParameter = lookup.longestPrefixCommand.Parameters.Add("@Key", SqliteType.Text);
             return lookup;
         }
 
@@ -85,6 +91,7 @@ namespace TrieHard.Alternatives.SQLite
                 isDisposed = true;
                 searchCommand?.Dispose();
                 getCommand?.Dispose();
+                longestPrefixCommand?.Dispose();
             }
         }
 
@@ -103,6 +110,17 @@ namespace TrieHard.Alternatives.SQLite
         {
             getKeyParameter!.Value = key;
             var valueIndex = getCommand!.ExecuteScalar();
+            if (valueIndex == null)
+            {
+                return default!;
+            }
+            return values[(long)valueIndex];
+        }
+
+        public T? LongestPrefix(string key)
+        {
+            longestPrefixKeyParameter!.Value = key;
+            var valueIndex = longestPrefixCommand!.ExecuteScalar();
             if (valueIndex == null)
             {
                 return default!;

--- a/src/TrieHard.Alternatives/SimpleTrie/SimpleNode.cs
+++ b/src/TrieHard.Alternatives/SimpleTrie/SimpleNode.cs
@@ -51,6 +51,43 @@ namespace TrieHard.Collections
             return GetNode(keySegment)!.Value;
         }
 
+        public T? LongestPrefix(ReadOnlySpan<char> keySegment)
+        {
+            T? longestValue = default;
+            bool hasLongestValue = HasValue;
+
+            if (hasLongestValue)
+            {
+                longestValue = Value;
+            }
+
+            if (keySegment.Length == 0)
+            {
+                return hasLongestValue ? longestValue : default;
+            }
+
+            var searchNode = this;
+
+            while (keySegment.Length > 0)
+            {
+                if (!searchNode.Children.TryGetValue(keySegment[0], out var child))
+                {
+                    break;
+                }
+
+                searchNode = child;
+                if (searchNode.HasValue)
+                {
+                    longestValue = searchNode.Value;
+                    hasLongestValue = true;
+                }
+
+                keySegment = keySegment.Slice(1);
+            }
+
+            return hasLongestValue ? longestValue : default;
+        }
+
         public IEnumerable<KeyValue<T?>> Search(string keySegment)
         {
             var matchingRoot = GetNode(keySegment);

--- a/src/TrieHard.Alternatives/SimpleTrie/SimpleTrie.cs
+++ b/src/TrieHard.Alternatives/SimpleTrie/SimpleTrie.cs
@@ -60,6 +60,11 @@ namespace TrieHard.Collections
             return rootNode.Search(keyPrefix);
         }
 
+        public T? LongestPrefix(string key)
+        {
+            return rootNode.LongestPrefix(key);
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();

--- a/src/TrieHard.PrefixLookup/IPrefixLookup.cs
+++ b/src/TrieHard.PrefixLookup/IPrefixLookup.cs
@@ -51,6 +51,14 @@
         IEnumerable<TValue?> SearchValues(string keyPrefix);
 
         /// <summary>
+        /// Returns the value associated with the stored key that is the longest prefix of the supplied key.
+        /// If no stored key is a prefix of the supplied key, returns the default value.
+        /// </summary>
+        /// <param name="key">The key to search for a longest stored prefix match</param>
+        /// <returns>The value associated with the longest matching stored prefix, or default(TValue)</returns>
+        TValue? LongestPrefix(string key);
+
+        /// <summary>
         /// If this type of lookup can be modified after creation or not.
         /// </summary>
         virtual static bool IsImmutable => false;

--- a/src/TrieHard.PrefixLookup/Node.cs
+++ b/src/TrieHard.PrefixLookup/Node.cs
@@ -457,6 +457,54 @@ internal class Node<T>
         return default;
     }
 
+    public T? LongestPrefix(ReadOnlySpan<byte> key)
+    {
+        T? longestValue = default;
+        bool hasLongestValue = Value is not null;
+
+        if (hasLongestValue)
+        {
+            longestValue = Value;
+        }
+
+        if (key.Length == 0)
+        {
+            return hasLongestValue ? longestValue : default;
+        }
+
+        var searchNode = this;
+
+        while (key.Length > 0)
+        {
+            int matchingIndex = searchNode.FindChildByFirstByte(key[0]);
+            if (matchingIndex < 0)
+            {
+                break;
+            }
+
+            searchNode = searchNode.childrenBuffer[matchingIndex];
+
+            var keySegment = searchNode.KeySegmentSpan;
+            int keyLength = keySegment.Length;
+            int matchingBytes = keyLength == 1 ? 1 : key.CommonPrefixLength(keySegment);
+
+            if (matchingBytes != keyLength)
+            {
+                break;
+            }
+
+            key = key.Slice(matchingBytes);
+
+            if (searchNode.Value is not null)
+            {
+                longestValue = searchNode.Value;
+                hasLongestValue = true;
+            }
+        }
+
+        return hasLongestValue ? longestValue : default;
+    }
+
     internal Node<T>? FindPrefixMatch(ReadOnlySpan<byte> key)
     {
         var node = this;

--- a/src/TrieHard.PrefixLookup/PrefixLookup.cs
+++ b/src/TrieHard.PrefixLookup/PrefixLookup.cs
@@ -92,6 +92,18 @@ public class PrefixLookup<T> : IPrefixLookup<T>
         return root.Get(key);
     }
 
+    public T? LongestPrefix(string key)
+    {
+        Span<byte> keyBuffer = stackalloc byte[key.Length * 4];
+        Span<byte> keySpan = GetKeyStringBytes(key, keyBuffer);
+        return LongestPrefix(keySpan);
+    }
+
+    public T? LongestPrefix(ReadOnlySpan<byte> key)
+    {
+        return root.LongestPrefix(key);
+    }
+
     public void Clear()
     {
         root.Reset();

--- a/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
+++ b/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
@@ -20,6 +20,14 @@ namespace TrieHard.Collections
         public static Concurrency ThreadSafety => Concurrency.None;
         public static bool IsSorted => true;
 
+        private const int InitialNodeBufferSize = 4096;
+        private const int MaxStackAllocSize = 4096;
+
+        /// <summary>
+        /// Maximum UTF-8 bytes a UTF-16 string of the given length could produce.
+        /// </summary>
+        private static int KeyMaxByteSize(int utf16Length) => Encoding.UTF8.GetMaxByteCount(utf16Length);
+
         private List<UnsafeTrieNodeBuffer> buffers = new List<UnsafeTrieNodeBuffer>();
         private UnsafeTrieNodeBuffer buffer;
         private nuint nodeCount = 0;
@@ -42,8 +50,8 @@ namespace TrieHard.Collections
 
         public UnsafeTrie()
         {
-            this.buffer = new UnsafeTrieNodeBuffer(4096);
-            this.buffers.Add(buffer);
+            buffer = new UnsafeTrieNodeBuffer(InitialNodeBufferSize);
+            buffers.Add(buffer);
             CreateRoot();
         }
 
@@ -63,21 +71,20 @@ namespace TrieHard.Collections
                 var newCapacity = buffer.Size * 2;
                 var newBuffer = new UnsafeTrieNodeBuffer(newCapacity);
                 buffers.Add(newBuffer);
-                this.buffer = newBuffer;
+                buffer = newBuffer;
             }
         }
 
         private void RecordNode()
         {
-            this.buffer.Advance(UnsafeTrieNode.Size);
+            buffer.Advance(UnsafeTrieNode.Size);
             nodeCount++;
         }
 
         public void Set(string key, T? value)
         {
-            var maxByteSize = key.Length * 4;
-
-            if (key.Length > 4096)
+            var maxByteSize = KeyMaxByteSize(key.Length);
+            if (maxByteSize > MaxStackAllocSize)
             {
                 var buffer = ArrayPool<byte>.Shared.Rent(maxByteSize);
                 Span<byte> keySpan = buffer.AsSpan();
@@ -143,7 +150,7 @@ namespace TrieHard.Collections
                 return Search(EmptyKeyBytes);
             }
 
-            var maxByteSize = key.Length * 4;
+            var maxByteSize = KeyMaxByteSize(key.Length);
             var buffer = ArrayPool<byte>.Shared.Rent(maxByteSize);
             Span<byte> keySpan = buffer.AsSpan();
             Utf8.FromUtf16(key, keySpan, out var _, out var bytesWritten, false, true);
@@ -183,8 +190,8 @@ namespace TrieHard.Collections
 
         public UnsafeTrieValueEnumerator<T?> SearchValues(string keyPrefix)
         {
-            var maxByteSize = keyPrefix.Length * 3;
-            if (maxByteSize > 4096)
+            var maxByteSize = KeyMaxByteSize(keyPrefix.Length);
+            if (maxByteSize > MaxStackAllocSize)
             {
                 var buffer = ArrayPool<byte>.Shared.Rent(maxByteSize);
                 Span<byte> keySpan = buffer.AsSpan();
@@ -230,9 +237,8 @@ namespace TrieHard.Collections
 
         public T? Get(string key)
         {
-            int keyByteMaxSize = key.Length * 4;
-
-            if (key.Length > 4096)
+            int keyByteMaxSize = KeyMaxByteSize(key.Length);
+            if (keyByteMaxSize > MaxStackAllocSize)
             {
                 Span<byte> keySpan;
                 var buffer = ArrayPool<byte>.Shared.Rent(keyByteMaxSize);
@@ -269,9 +275,8 @@ namespace TrieHard.Collections
 
         public T? LongestPrefix(string key)
         {
-            int keyByteMaxSize = key.Length * 4;
-
-            if (key.Length > 4096)
+            int keyByteMaxSize = KeyMaxByteSize(key.Length);
+            if (keyByteMaxSize > MaxStackAllocSize)
             {
                 Span<byte> keySpan;
                 var buffer = ArrayPool<byte>.Shared.Rent(keyByteMaxSize);
@@ -282,11 +287,13 @@ namespace TrieHard.Collections
                 ArrayPool<byte>.Shared.Return(buffer);
                 return result;
             }
-
-            Span<byte> stackKeySpan = stackalloc byte[keyByteMaxSize];
-            Utf8.FromUtf16(key, stackKeySpan, out var _, out var stackBytesWritten, false, true);
-            stackKeySpan = stackKeySpan.Slice(0, stackBytesWritten);
-            return LongestPrefix(stackKeySpan);
+            else
+            {
+                Span<byte> stackKeySpan = stackalloc byte[keyByteMaxSize];
+                Utf8.FromUtf16(key, stackKeySpan, out var _, out var stackBytesWritten, false, true);
+                stackKeySpan = stackKeySpan.Slice(0, stackBytesWritten);
+                return LongestPrefix(stackKeySpan);
+            }
         }
 
         public T? LongestPrefix(ReadOnlySpan<byte> key)
@@ -385,17 +392,17 @@ namespace TrieHard.Collections
 
         IEnumerable<KeyValue<T?>> IPrefixLookup<T?>.Search(string keyPrefix)
         {
-            return this.Search(keyPrefix);
+            return Search(keyPrefix);
         }
 
         IEnumerator<KeyValue<T?>> IEnumerable<KeyValue<T?>>.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
 

--- a/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
+++ b/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
@@ -52,7 +52,7 @@ namespace TrieHard.Collections
             var nodeSize = UnsafeTrieNode.Size;
             EnsureNodeSpace();
             rootPointer = (UnsafeTrieNode*)buffer.CurrentAddress;
-            *rootPointer = new UnsafeTrieNode();
+            *rootPointer = new UnsafeTrieNode { ValueLocation = -1 };
             RecordNode();
         }
 

--- a/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
+++ b/src/TrieHard.PrefixLookup/Unsafe/UnsafeTrie.cs
@@ -267,6 +267,66 @@ namespace TrieHard.Collections
             return values[node->ValueLocation];
         }
 
+        public T? LongestPrefix(string key)
+        {
+            int keyByteMaxSize = key.Length * 4;
+
+            if (key.Length > 4096)
+            {
+                Span<byte> keySpan;
+                var buffer = ArrayPool<byte>.Shared.Rent(keyByteMaxSize);
+                keySpan = buffer.AsSpan();
+                Utf8.FromUtf16(key, keySpan, out var _, out var bytesWritten, false, true);
+                keySpan = keySpan.Slice(0, bytesWritten);
+                var result = LongestPrefix(keySpan);
+                ArrayPool<byte>.Shared.Return(buffer);
+                return result;
+            }
+
+            Span<byte> stackKeySpan = stackalloc byte[keyByteMaxSize];
+            Utf8.FromUtf16(key, stackKeySpan, out var _, out var stackBytesWritten, false, true);
+            stackKeySpan = stackKeySpan.Slice(0, stackBytesWritten);
+            return LongestPrefix(stackKeySpan);
+        }
+
+        public T? LongestPrefix(ReadOnlySpan<byte> key)
+        {
+            int longestValueLocation = rootPointer->ValueLocation;
+
+            if (key.Length == 0)
+            {
+                return longestValueLocation > -1 ? values[longestValueLocation] : default!;
+            }
+
+            int keyIndex = 0;
+            UnsafeTrieNode* searchNode = rootPointer;
+            while (keyIndex < key.Length)
+            {
+                byte byteToMatch = key[keyIndex];
+
+                var matchingIndex = searchNode->BinarySearch(byteToMatch);
+                if (matchingIndex < 0)
+                {
+                    break;
+                }
+
+                searchNode = (UnsafeTrieNode*)searchNode->GetChild(matchingIndex).ToPointer();
+                if (searchNode->ValueLocation > -1)
+                {
+                    longestValueLocation = searchNode->ValueLocation;
+                }
+
+                keyIndex++;
+            }
+
+            if (longestValueLocation < 0)
+            {
+                return default!;
+            }
+
+            return values[longestValueLocation];
+        }
+
         public void Dispose()
         {
             if (isDisposed)

--- a/test/TrieHard.Benchmarks/LookupBenchmark.cs
+++ b/test/TrieHard.Benchmarks/LookupBenchmark.cs
@@ -16,6 +16,7 @@ namespace TrieHard.Benchmarks
         protected T lookup;
         protected const string testKey = "555555";
         protected const string testPrefixKey = "55555";
+        protected const string testLongestPrefixKey = "555555x";
 
         [GlobalSetup]
         public virtual void Setup()
@@ -65,6 +66,12 @@ namespace TrieHard.Benchmarks
                 result = value;
             }
             return result;
+        }
+
+        [Benchmark]
+        public virtual string LongestPrefix()
+        {
+            return lookup.LongestPrefix(testLongestPrefixKey);
         }
 
         [Benchmark]

--- a/test/TrieHard.Benchmarks/PrefixLookup.cs
+++ b/test/TrieHard.Benchmarks/PrefixLookup.cs
@@ -79,6 +79,12 @@ namespace TrieHard.Benchmarks
             return result;
         }
 
+        [Benchmark]
+        public string LongestPrefix_Utf8()
+        {
+            return lookup.LongestPrefix(TestData.LongestPrefixKeyBytes.Span);
+        }
+
 
 
     }

--- a/test/TrieHard.Benchmarks/TestData.cs
+++ b/test/TrieHard.Benchmarks/TestData.cs
@@ -31,6 +31,7 @@ namespace TrieHard.Benchmarks
         public const string Prefix = "34567";
         public static readonly ReadOnlyMemory<byte> KeyBytes =    "345678"u8.ToArray().AsMemory();
         public static readonly ReadOnlyMemory<byte> PrefixBytes = "34567"u8.ToArray().AsMemory();
+        public static readonly ReadOnlyMemory<byte> LongestPrefixKeyBytes = "345678x"u8.ToArray().AsMemory();
         static TestData()
         {
             Sequential = new KeyValue<string>[1_000_000];

--- a/test/TrieHard.Benchmarks/Unsafe.cs
+++ b/test/TrieHard.Benchmarks/Unsafe.cs
@@ -70,6 +70,12 @@ namespace TrieHard.Benchmarks
             return result;
         }
 
+        [Benchmark]
+        public string LongestPrefix_Utf8()
+        {
+            return lookup.LongestPrefix(TestData.LongestPrefixKeyBytes.Span);
+        }
+
 
 
 

--- a/test/TrieHard.Tests/PrefixLookupTests.cs
+++ b/test/TrieHard.Tests/PrefixLookupTests.cs
@@ -79,6 +79,73 @@ public abstract class PrefixLookupTests<T> where T : IPrefixLookup<TestRecord?>
     }
 
     [Test]
+    public void LongestPrefix_FindsExactMatch()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+        T lookup = (T)T.Create(testKvpEnumerable!);
+        var result = lookup.LongestPrefix(TestKey);
+        Assert.That(result, Is.SameAs(TestRecord));
+    }
+
+    [Test]
+    public void LongestPrefix_FindsLongestStoredPrefix()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+
+        var shorterMatch = new TestRecord("ab");
+        var longerMatch = new TestRecord("abcd");
+
+        T lookup = (T)T.Create(new[]
+        {
+            new KeyValue<TestRecord?>("a", new TestRecord("a")),
+            new KeyValue<TestRecord?>("ab", shorterMatch),
+            new KeyValue<TestRecord?>("abcd", longerMatch),
+        });
+
+        var result = lookup.LongestPrefix("abcde");
+
+        Assert.That(result, Is.SameAs(longerMatch));
+    }
+
+    [Test]
+    public void LongestPrefix_WhenKeyEndsWithinUnvaluedPath_ReturnsLastStoredPrefix()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+
+        var shorterMatch = new TestRecord("ab");
+        var longerMatch = new TestRecord("abcd");
+
+        T lookup = (T)T.Create(new[]
+        {
+            new KeyValue<TestRecord?>("ab", shorterMatch),
+            new KeyValue<TestRecord?>("abcd", longerMatch),
+        });
+
+        var result = lookup.LongestPrefix("abc");
+
+        Assert.That(result, Is.SameAs(shorterMatch));
+    }
+
+    [Test]
+    public void LongestPrefix_WhenNoStoredPrefixMatches_ReturnsNull()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+        T lookup = (T)T.Create(testKvpEnumerable!);
+        var result = lookup.LongestPrefix("NoMatch");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void LongestPrefix_EmptyKeyInput_ReturnsNull()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+        T lookup = (T)T.Create(testKvpEnumerable!);
+        // No empty-key value stored, should return null
+        var result = lookup.LongestPrefix("");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
     public void Search_FindsKeyByPrefix()
     {
         Assume.That(CreateWithValues, Throws.Nothing);
@@ -274,6 +341,7 @@ public abstract class PrefixLookupTests<T> where T : IPrefixLookup<TestRecord?>
 public class SimpleTrieTests : PrefixLookupTests<SimpleTrie<TestRecord?>> { }
 public class SqliteLookupTests : PrefixLookupTests<SQLiteLookup<TestRecord?>> { }
 public class ListPrefixLookupTests : PrefixLookupTests<ListPrefixLookup<TestRecord?>> { }
+public class UnsafeTrieTests : PrefixLookupTests<UnsafeTrie<TestRecord?>> { }
 public class PrefixLookupTests : PrefixLookupTests<PrefixLookup<TestRecord?>> 
 {
 
@@ -318,4 +386,3 @@ public class PrefixLookupTests : PrefixLookupTests<PrefixLookup<TestRecord?>>
     }
 
 }
-public class UnsafeTrieTests : PrefixLookupTests<UnsafeTrie<TestRecord?>> { }

--- a/test/TrieHard.Tests/PrefixLookupTests.cs
+++ b/test/TrieHard.Tests/PrefixLookupTests.cs
@@ -254,6 +254,20 @@ public abstract class PrefixLookupTests<T> where T : IPrefixLookup<TestRecord?>
         }
         Assert.That(lookup.Count, Is.EqualTo(valuesToAdd));
     }
+
+    [Test]
+    public void Enumerate_DoesNotYieldPhantomRootEntry()
+    {
+        Assume.That(CreateWithValues, Throws.Nothing);
+        T lookup = (T)T.Create(testKvpEnumerable!);
+
+        var keys = new List<string>();
+        foreach (var kv in (IEnumerable<KeyValue<TestRecord?>>)lookup)
+            keys.Add(kv.Key);
+
+        Assert.That(keys, Has.Count.EqualTo(lookup.Count));
+        Assert.That(keys, Has.None.EqualTo(""));
+    }
 }
 
 


### PR DESCRIPTION
fixes #16 

Quick and dirty first pass.
+ updated UnsafeTrie to use tighter bound for bytes, rather than hardcoded 4x

Note: this is based off #17 branch, since correctness depended on it.